### PR TITLE
RtpCommand.tp(): return not just positive coords

### DIFF
--- a/common/src/main/java/earth/terrarium/prometheus/common/commands/utilities/RtpCommand.java
+++ b/common/src/main/java/earth/terrarium/prometheus/common/commands/utilities/RtpCommand.java
@@ -74,8 +74,8 @@ public class RtpCommand {
         final int min = distance / 4;
         final int max = distance - min;
 
-        int x = min + player.getRandom().nextInt(-max, max) + location.getX();
-        int z = min + player.getRandom().nextInt(-max, max) + location.getZ();
+        int x = min + (player.getRandom().nextInt(2 * max) - max) + location.getX();
+        int z = min + (player.getRandom().nextInt(2 * max) - max) + location.getZ();
 
         if (!level.getWorldBorder().isWithinBounds(x, z) || level.getBiome(new BlockPos(x, level.getSeaLevel(), z)).is(BiomeTags.IS_OCEAN)) {
             return tp(location, player, distance, tries + 1);


### PR DESCRIPTION
IntelliJ's decompile shows getRandom().nextInt(origin, bound) to not work like it seems was assumed.

I have _not_ compiled and checked this fix.