### PR TITLE
[1.20.x] Fix /spawn position randomizing when it shouldnt.

### DIFF
--- a/common/src/main/java/earth/terrarium/prometheus/common/commands/utilities/TpCommand.java
+++ b/common/src/main/java/earth/terrarium/prometheus/common/commands/utilities/TpCommand.java
@@ -32,9 +32,12 @@ public class TpCommand {
         dispatcher.register(Commands.literal("spawn")
             .executes(context -> {
                 ServerPlayer player = context.getSource().getPlayerOrException();
-                BlockPos pos = player.level().getHeightmapPos(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, player.level().getSharedSpawnPos());
+                BlockPos pos = player.level().getSharedSpawnPos();
                 if (!RtpCommand.isSafe(player, pos)) {
-                    pos = RtpCommand.tp(pos, player, 10, 0);
+                    pos = player.level().getHeightmapPos(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, pos);
+                    if (!RtpCommand.isSafe(player, pos)) {
+                        pos = RtpCommand.tp(pos, player, 10, 0);
+                    }
                 }
                 if (pos == null) {
                     player.sendSystemMessage(ConstantComponents.CANT_FIND_LOCATION);


### PR DESCRIPTION
/spawn will attempt to use the world's spawn position without any heightmap adjustments, and only try to adjust if the position isn't safe.