### PR TITLE
My bad--This should be a correct rtp function

### DIFF
--- a/common/src/main/java/earth/terrarium/prometheus/common/commands/utilities/RtpCommand.java
+++ b/common/src/main/java/earth/terrarium/prometheus/common/commands/utilities/RtpCommand.java
@@ -74,13 +74,10 @@ public class RtpCommand {
         final int min = distance / 4;
         final int max = distance - min;
 
-        boolean flipX = player.getRandom().nextDouble() < 0.5;
-        int randRangeX = min + player.getRandom().nextInt(max);
-        int x = location.getX() + (randRangeX * (flipX ? -1 : 1));
-
-        boolean flipZ = player.getRandom().nextDouble() < 0.5;
-        int randRangeZ = min + player.getRandom().nextInt(max);
-        int z = location.getZ() + (randRangeZ * (flipZ ? -1 : 1));
+        var theta = player.getRandom().nextDouble() * 2 * Math.PI;
+        int r = min + player.getRandom().nextInt(max);
+        int x = Math.round(r * (float) Math.cos(theta));
+        int z = Math.round(r * (float) Math.sin(theta));
 
         if (!level.getWorldBorder().isWithinBounds(x, z) || level.getBiome(new BlockPos(x, level.getSeaLevel(), z)).is(BiomeTags.IS_OCEAN)) {
             return tp(location, player, distance, tries + 1);

--- a/common/src/main/java/earth/terrarium/prometheus/common/commands/utilities/RtpCommand.java
+++ b/common/src/main/java/earth/terrarium/prometheus/common/commands/utilities/RtpCommand.java
@@ -74,8 +74,13 @@ public class RtpCommand {
         final int min = distance / 4;
         final int max = distance - min;
 
-        int x = min + player.getRandom().nextInt(-max, max) + location.getX();
-        int z = min + player.getRandom().nextInt(-max, max) + location.getZ();
+        boolean flipX = player.getRandom().nextDouble() < 0.5;
+        int randRangeX = min + player.getRandom().nextInt(max);
+        int x = location.getX() + (randRangeX * (flipX ? -1 : 1));
+
+        boolean flipZ = player.getRandom().nextDouble() < 0.5;
+        int randRangeZ = min + player.getRandom().nextInt(max);
+        int z = location.getZ() + (randRangeZ * (flipZ ? -1 : 1));
 
         if (!level.getWorldBorder().isWithinBounds(x, z) || level.getBiome(new BlockPos(x, level.getSeaLevel(), z)).is(BiomeTags.IS_OCEAN)) {
             return tp(location, player, distance, tries + 1);


### PR DESCRIPTION
This should be correct. Certainly is shorter, and clearer too, imho.

My previous patch to the rtp function, while making all four quadrants accessible, did have a bone-headed logic error. Natte was kind enough to graph those result, making the error plain:

![image](https://github.com/terrarium-earth/Prometheus/assets/6677700/d9b85daf-6c1e-4f42-93c8-501a8345f252)
